### PR TITLE
Remove setup_requires packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,6 @@ setuptools.setup(
     url='https://github.com/ampledata/aprs',
     zip_safe=False,
     include_package_data=True,
-    setup_requires=[
-      'coverage >= 3.7.1',
-      'httpretty >= 0.8.10',
-      'nose >= 1.3.7'
-    ],
     install_requires=[
         'kiss >= 6.0.0',
         'requests >= 2.7.0'


### PR DESCRIPTION
The packages described in setup_requires were not required to run setup.py.