### PR TITLE
Fix error when attempting to send a frame.

### DIFF
--- a/aprs/classes.py
+++ b/aprs/classes.py
@@ -340,7 +340,7 @@ class TCP(APRS):
         self._logger.info('Sending frame="%s"', frame)
 
         # Unicode Sandwich: Send bytes.
-        _frame = bytes(frame + b'\n\r')
+        _frame = bytes(frame) + b'\n\r'
 
         return self.interface.send(_frame)
 


### PR DESCRIPTION
When attempting to send a frame using the TCP class you get the following error:

raceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jboline/anaconda3/lib/python3.6/site-packages/aprs/classes.py", line 343, in send
    _frame = bytes(frame + b'\n\r')
TypeError: unsupported operand type(s) for +: 'Frame' and 'bytes'

This change fixes the error. (Tested in python 3.6.2)