### PR TITLE
Fixes and optimisations

### DIFF
--- a/aprs/__init__.py
+++ b/aprs/__init__.py
@@ -31,7 +31,7 @@ from .geo_util import dec2dm_lat, dec2dm_lng, ambiguate  # NOQA
 from .fcs import FCS  # NOQA
 
 from .functions import (parse_frame, parse_frame_text, parse_callsign,   # NOQA
-                        parse_callsign_ax25, parse_info_field)
+                        parse_callsign_ax25, parse_callsign_text, parse_info_field)
 
 from .classes import (Frame, Callsign, APRS, TCP, UDP, HTTP,  # NOQA
                       InformationField, PositionFrame)

--- a/aprs/__init__.py
+++ b/aprs/__init__.py
@@ -30,7 +30,7 @@ from .geo_util import dec2dm_lat, dec2dm_lng, ambiguate  # NOQA
 
 from .fcs import FCS  # NOQA
 
-from .functions import (parse_frame, parse_callsign,   # NOQA
+from .functions import (parse_frame, parse_frame_text, parse_callsign,   # NOQA
                         parse_callsign_ax25, parse_info_field)
 
 from .classes import (Frame, Callsign, APRS, TCP, UDP, HTTP,  # NOQA

--- a/aprs/classes.py
+++ b/aprs/classes.py
@@ -323,7 +323,7 @@ class TCP(APRS):
 
         return self.interface.send(_frame)
 
-    def receive(self, callback=None, frame_handler=aprs.parse_frame):
+    def receive(self, callback=None, frame_handler=aprs.parse_frame_text):
         """
         Receives from APRS-IS.
 

--- a/aprs/classes.py
+++ b/aprs/classes.py
@@ -30,13 +30,6 @@ class Frame(object):
     __slots__ = ['source', 'destination', 'path', 'info']
 
     _logger = logging.getLogger(__name__)  # pylint: disable=R0801
-    if not _logger.handlers:  # pylint: disable=R0801
-        _logger.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler = logging.StreamHandler()  # pylint: disable=R0801
-        _console_handler.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler.setFormatter(aprs.LOG_FORMAT)  # pylint: disable=R0801
-        _logger.addHandler(_console_handler)  # pylint: disable=R0801
-        _logger.propagate = False  # pylint: disable=R0801
 
     def __init__(self, source: bytes=b'', destination: bytes=b'',
                  path: list=[], info: bytes=b'') -> None:
@@ -116,13 +109,6 @@ class Callsign(object):
     """
 
     _logger = logging.getLogger(__name__)  # pylint: disable=R0801
-    if not _logger.handlers:  # pylint: disable=R0801
-        _logger.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler = logging.StreamHandler()  # pylint: disable=R0801
-        _console_handler.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler.setFormatter(aprs.LOG_FORMAT)  # pylint: disable=R0801
-        _logger.addHandler(_console_handler)  # pylint: disable=R0801
-        _logger.propagate = False  # pylint: disable=R0801
 
     __slots__ = ['callsign', 'ssid', 'digi']
 
@@ -214,13 +200,6 @@ class APRS(object):
     """APRS Object."""
 
     _logger = logging.getLogger(__name__)  # pylint: disable=R0801
-    if not _logger.handlers:  # pylint: disable=R0801
-        _logger.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler = logging.StreamHandler()  # pylint: disable=R0801
-        _console_handler.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler.setFormatter(aprs.LOG_FORMAT)  # pylint: disable=R0801
-        _logger.addHandler(_console_handler)  # pylint: disable=R0801
-        _logger.propagate = False  # pylint: disable=R0801
 
     def __init__(self, user: bytes, password: bytes=b'-1') -> None:
         if isinstance(user, str):
@@ -472,13 +451,6 @@ class InformationField(object):
     """
 
     _logger = logging.getLogger(__name__)  # pylint: disable=R0801
-    if not _logger.handlers:  # pylint: disable=R0801
-        _logger.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler = logging.StreamHandler()  # pylint: disable=R0801
-        _console_handler.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler.setFormatter(aprs.LOG_FORMAT)  # pylint: disable=R0801
-        _logger.addHandler(_console_handler)  # pylint: disable=R0801
-        _logger.propagate = False  # pylint: disable=R0801
 
     __slots__ = ['data_type', 'data', 'safe']
 
@@ -508,13 +480,6 @@ class PositionFrame(Frame):
                  'symbol', 'comment', 'ambiguity']
 
     _logger = logging.getLogger(__name__)  # pylint: disable=R0801
-    if not _logger.handlers:  # pylint: disable=R0801
-        _logger.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler = logging.StreamHandler()  # pylint: disable=R0801
-        _console_handler.setLevel(aprs.LOG_LEVEL)  # pylint: disable=R0801
-        _console_handler.setFormatter(aprs.LOG_FORMAT)  # pylint: disable=R0801
-        _logger.addHandler(_console_handler)  # pylint: disable=R0801
-        _logger.propagate = False  # pylint: disable=R0801
 
     def __init__(self, source: bytes, destination: bytes, path: typing.List,
                  table: bytes, symbol: bytes, comment: bytes, lat: float,

--- a/aprs/functions.py
+++ b/aprs/functions.py
@@ -36,24 +36,22 @@ def parse_frame_text(raw_frame: bytes) -> AprsFrame:
     Parses and Extracts the components of a str Frame.
     """
     parsed_frame = aprs.Frame()
-    _path = []
 
     # Source>Destination
     sd_delim = raw_frame.index(b'>')
 
-    parsed_frame.set_source(raw_frame[:sd_delim])
+    parsed_frame.source = aprs.parse_callsign_text(raw_frame[:sd_delim])
 
     # Path:Info
     pi_delim = raw_frame.index(b':')
 
     parsed_path = raw_frame[sd_delim + 1:pi_delim]
     if b',' in parsed_path:
-        for path in parsed_path.split(b','):
-            _path.append(path)
-        parsed_frame.set_destination(_path.pop(0))
-        parsed_frame.set_path(_path)
+        _path = parsed_path.split(b',')
+        parsed_frame.destination  = aprs.parse_callsign_text(_path[0])
+        parsed_frame.path = [aprs.parse_callsign_text(pth) for pth in _path[1:]]
     else:
-        parsed_frame.set_destination(parsed_path)
+        parsed_frame.destination  = aprs.parse_callsign_text(parsed_path)
 
     parsed_frame.set_info(raw_frame[pi_delim + 1:])
 


### PR DESCRIPTION
I'm trying to use the parser at the 2500 packets/second OGN feed, and it doesn't work out, it's too slow. I did a few obvious fixes and optimisations, but I will likely stop here at this point and do something completely different instead, as modifying this module to do it would be quite a lot of work.

An overall issue is that the setter methods of Frame take any sort of input, and the APRS-IS parser gives it (binary) strings, and the setters try to handle them as **everything else** except strings. It would be faster and more correct to directly process them as strings when we certainly know we have APRS-IS strings in the variable, instead of checking if they would have turned into objects or something else instead. Similar patterns seem to appear elsewhere.

For example, APRS-IS callsign strings here are first tested if they're already decoded objects (no we gave it a string), and then the binary AX.25 callsign parser is tried (fails always, slow, raises exception on every call: source, destination, path elements), and then it goes for the correct parser. As a result, the code spends up parsing callsigns for most of the time, if looking at it in the profiler. https://github.com/ampledata/aprs/blob/master/aprs/functions.py#L101

And I fixed the module to not overwrite logging setup; it insisted on writing things to the console.